### PR TITLE
свитчаем на Zig и Limine

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,247 @@
+# Nuke built-in rules and variables.
+MAKEFLAGS += -rR
+.SUFFIXES:
+
+# Target architecture to build for. Default to x86_64.
+ARCH := x86_64
+
+# Default user QEMU flags. These are appended to the QEMU command calls.
+QEMUFLAGS := -m 2G
+
+override IMAGE_NAME := ZernOS-$(ARCH)
+
+# Toolchain for building the 'limine' executable for the host.
+HOST_CC := cc
+HOST_CFLAGS := -g -O2 -pipe
+HOST_CPPFLAGS :=
+HOST_LDFLAGS :=
+HOST_LIBS :=
+
+.PHONY: all
+all: $(IMAGE_NAME).iso
+
+.PHONY: all-hdd
+all-hdd: $(IMAGE_NAME).hdd
+
+.PHONY: run
+run: run-$(ARCH)
+
+.PHONY: run-hdd
+run-hdd: run-hdd-$(ARCH)
+
+.PHONY: run-x86_64
+run-x86_64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).iso
+	qemu-system-$(ARCH) \
+		-M q35 \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-cdrom $(IMAGE_NAME).iso \
+		$(QEMUFLAGS)
+
+.PHONY: run-hdd-x86_64
+run-hdd-x86_64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).hdd
+	qemu-system-$(ARCH) \
+		-M q35 \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-hda $(IMAGE_NAME).hdd \
+		$(QEMUFLAGS)
+
+.PHONY: run-aarch64
+run-aarch64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).iso
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu cortex-a72 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-cdrom $(IMAGE_NAME).iso \
+		$(QEMUFLAGS)
+
+.PHONY: run-hdd-aarch64
+run-hdd-aarch64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).hdd
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu cortex-a72 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-hda $(IMAGE_NAME).hdd \
+		$(QEMUFLAGS)
+
+.PHONY: run-riscv64
+run-riscv64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).iso
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu rv64 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-cdrom $(IMAGE_NAME).iso \
+		$(QEMUFLAGS)
+
+.PHONY: run-hdd-riscv64
+run-hdd-riscv64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).hdd
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu rv64 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-hda $(IMAGE_NAME).hdd \
+		$(QEMUFLAGS)
+
+.PHONY: run-loongarch64
+run-loongarch64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).iso
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu la464 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-cdrom $(IMAGE_NAME).iso \
+		$(QEMUFLAGS)
+
+.PHONY: run-hdd-loongarch64
+run-hdd-loongarch64: ovmf/ovmf-code-$(ARCH).fd $(IMAGE_NAME).hdd
+	qemu-system-$(ARCH) \
+		-M virt \
+		-cpu la464 \
+		-device ramfb \
+		-device qemu-xhci \
+		-device usb-kbd \
+		-device usb-mouse \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(ARCH).fd,readonly=on \
+		-hda $(IMAGE_NAME).hdd \
+		$(QEMUFLAGS)
+
+
+.PHONY: run-bios
+run-bios: $(IMAGE_NAME).iso
+	qemu-system-$(ARCH) \
+		-M q35 \
+		-cdrom $(IMAGE_NAME).iso \
+		-boot d \
+		$(QEMUFLAGS)
+
+.PHONY: run-hdd-bios
+run-hdd-bios: $(IMAGE_NAME).hdd
+	qemu-system-$(ARCH) \
+		-M q35 \
+		-hda $(IMAGE_NAME).hdd \
+		$(QEMUFLAGS)
+
+ovmf/ovmf-code-$(ARCH).fd:
+	mkdir -p ovmf
+	curl -Lo $@ https://github.com/osdev0/edk2-ovmf-nightly/releases/latest/download/ovmf-code-$(ARCH).fd
+	case "$(ARCH)" in \
+		aarch64) dd if=/dev/zero of=$@ bs=1 count=0 seek=67108864 2>/dev/null;; \
+		riscv64) dd if=/dev/zero of=$@ bs=1 count=0 seek=33554432 2>/dev/null;; \
+	esac
+
+limine/limine:
+	rm -rf limine
+	git clone https://github.com/limine-bootloader/limine.git --branch=v9.x-binary --depth=1
+	$(MAKE) -C limine \
+		CC="$(HOST_CC)" \
+		CFLAGS="$(HOST_CFLAGS)" \
+		CPPFLAGS="$(HOST_CPPFLAGS)" \
+		LDFLAGS="$(HOST_LDFLAGS)" \
+		LIBS="$(HOST_LIBS)"
+
+.PHONY: kernel
+kernel:
+	$(MAKE) -C kernel
+
+$(IMAGE_NAME).iso: limine/limine kernel
+	rm -rf iso_root
+	mkdir -p iso_root/boot
+	cp -v kernel/zig-out/bin-$(ARCH)/kernel iso_root/boot/
+	mkdir -p iso_root/boot/limine
+	cp -v limine.conf iso_root/boot/limine/
+	mkdir -p iso_root/EFI/BOOT
+ifeq ($(ARCH),x86_64)
+	cp -v limine/limine-bios.sys limine/limine-bios-cd.bin limine/limine-uefi-cd.bin iso_root/boot/limine/
+	cp -v limine/BOOTX64.EFI iso_root/EFI/BOOT/
+	cp -v limine/BOOTIA32.EFI iso_root/EFI/BOOT/
+	xorriso -as mkisofs -R -r -J -b boot/limine/limine-bios-cd.bin \
+		-no-emul-boot -boot-load-size 4 -boot-info-table -hfsplus \
+		-apm-block-size 2048 --efi-boot boot/limine/limine-uefi-cd.bin \
+		-efi-boot-part --efi-boot-image --protective-msdos-label \
+		iso_root -o $(IMAGE_NAME).iso
+	./limine/limine bios-install $(IMAGE_NAME).iso
+endif
+ifeq ($(ARCH),aarch64)
+	cp -v limine/limine-uefi-cd.bin iso_root/boot/limine/
+	cp -v limine/BOOTAA64.EFI iso_root/EFI/BOOT/
+	xorriso -as mkisofs -R -r -J \
+		-hfsplus -apm-block-size 2048 \
+		--efi-boot boot/limine/limine-uefi-cd.bin \
+		-efi-boot-part --efi-boot-image --protective-msdos-label \
+		iso_root -o $(IMAGE_NAME).iso
+endif
+ifeq ($(ARCH),riscv64)
+	cp -v limine/limine-uefi-cd.bin iso_root/boot/limine/
+	cp -v limine/BOOTRISCV64.EFI iso_root/EFI/BOOT/
+	xorriso -as mkisofs -R -r -J \
+		-hfsplus -apm-block-size 2048 \
+		--efi-boot boot/limine/limine-uefi-cd.bin \
+		-efi-boot-part --efi-boot-image --protective-msdos-label \
+		iso_root -o $(IMAGE_NAME).iso
+endif
+ifeq ($(ARCH),loongarch64)
+	cp -v limine/limine-uefi-cd.bin iso_root/boot/limine/
+	cp -v limine/BOOTLOONGARCH64.EFI iso_root/EFI/BOOT/
+	xorriso -as mkisofs -R -r -J \
+		-hfsplus -apm-block-size 2048 \
+		--efi-boot boot/limine/limine-uefi-cd.bin \
+		-efi-boot-part --efi-boot-image --protective-msdos-label \
+		iso_root -o $(IMAGE_NAME).iso
+endif
+	rm -rf iso_root
+
+$(IMAGE_NAME).hdd: limine/limine kernel
+	rm -f $(IMAGE_NAME).hdd
+	dd if=/dev/zero bs=1M count=0 seek=64 of=$(IMAGE_NAME).hdd
+ifeq ($(ARCH),x86_64)
+	PATH=$$PATH:/usr/sbin:/sbin sgdisk $(IMAGE_NAME).hdd -n 1:2048 -t 1:ef00 -m 1
+	./limine/limine bios-install $(IMAGE_NAME).hdd
+else
+	PATH=$$PATH:/usr/sbin:/sbin sgdisk $(IMAGE_NAME).hdd -n 1:2048 -t 1:ef00
+endif
+	mformat -i $(IMAGE_NAME).hdd@@1M
+	mmd -i $(IMAGE_NAME).hdd@@1M ::/EFI ::/EFI/BOOT ::/boot ::/boot/limine
+	mcopy -i $(IMAGE_NAME).hdd@@1M kernel/zig-out/bin-$(ARCH)/kernel ::/boot
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine.conf ::/boot/limine
+ifeq ($(ARCH),x86_64)
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/limine-bios.sys ::/boot/limine
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOTX64.EFI ::/EFI/BOOT
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOTIA32.EFI ::/EFI/BOOT
+endif
+ifeq ($(ARCH),aarch64)
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOTAA64.EFI ::/EFI/BOOT
+endif
+ifeq ($(ARCH),riscv64)
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOTRISCV64.EFI ::/EFI/BOOT
+endif
+ifeq ($(ARCH),loongarch64)
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOTLOONGARCH64.EFI ::/EFI/BOOT
+endif
+
+.PHONY: clean
+clean:
+	$(MAKE) -C kernel clean
+	rm -rf iso_root $(IMAGE_NAME).iso $(IMAGE_NAME).hdd
+
+.PHONY: distclean
+distclean:
+	$(MAKE) -C kernel distclean
+	rm -rf iso_root *.iso *.hdd limine ovmf

--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -1,0 +1,51 @@
+# Nuke built-in rules and variables.
+MAKEFLAGS += -rR
+.SUFFIXES:
+
+# This is the name that our final executable will have.
+# Change as needed.
+override OUTPUT := kernel
+
+# Target architecture to build for. Default to x86_64.
+ARCH := x86_64
+
+# Install prefix; /usr/local is a good, standard default pick.
+PREFIX := /usr/local
+
+# Check if the architecture is supported.
+ifeq ($(filter $(ARCH),aarch64 loongarch64 riscv64 x86_64),)
+    $(error Architecture $(ARCH) not supported)
+endif
+
+# User controllable Zig compiler command.
+ZIG := zig
+
+# User controllable Zig flags.
+ZIGFLAGS := -Doptimize=ReleaseSafe
+
+# Default target.
+.PHONY: all
+all:
+	$(ZIG) build $(ZIGFLAGS) -Darch=$(ARCH)
+
+# Remove object files and the final executable.
+.PHONY: clean
+clean:
+	rm -rf .zig-cache zig-out
+
+# Remove everything built and generated including downloaded dependencies.
+.PHONY: distclean
+distclean:
+	rm -rf .zig-cache zig-out
+
+# Install the final built executable to its final on-root location.
+.PHONY: install
+install: all
+	install -d "$(DESTDIR)$(PREFIX)/share/$(OUTPUT)"
+	install -m 644 bin-$(ARCH)/$(OUTPUT) "$(DESTDIR)$(PREFIX)/share/$(OUTPUT)/$(OUTPUT)-$(ARCH)"
+
+# Try to undo whatever the "install" target did.
+.PHONY: uninstall
+uninstall:
+	rm -f "$(DESTDIR)$(PREFIX)/share/$(OUTPUT)/$(OUTPUT)-$(ARCH)"
+	-rmdir "$(DESTDIR)$(PREFIX)/share/$(OUTPUT)"

--- a/kernel/build.zig
+++ b/kernel/build.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+
+/// A list of architectures supported by the kernel.
+const Arch = enum {
+    x86_64,
+    aarch64,
+    riscv64,
+    loongarch64,
+
+    /// Convert the architecture to an std.Target.Cpu.Arch.
+    fn toStd(self: @This()) std.Target.Cpu.Arch {
+        return switch (self) {
+            .x86_64 => .x86_64,
+            .aarch64 => .aarch64,
+            .riscv64 => .riscv64,
+            .loongarch64 => .loongarch64,
+        };
+    }
+};
+
+/// Create a target query for the given architecture.
+/// The target needs to disable some features that are not supported
+/// in a bare-metal environment, such as SSE or AVX on x86_64.
+fn targetQueryForArch(arch: Arch) std.Target.Query {
+    var query: std.Target.Query = .{
+        .cpu_arch = arch.toStd(),
+        .os_tag = .freestanding,
+        .abi = .none,
+    };
+
+    switch (arch) {
+        .x86_64 => {
+            const Target = std.Target.x86;
+
+            query.cpu_features_add = Target.featureSet(&.{ .popcnt, .soft_float });
+            query.cpu_features_sub = Target.featureSet(&.{ .avx, .avx2, .sse, .sse2, .mmx });
+        },
+        .aarch64 => {
+            const Target = std.Target.aarch64;
+
+            query.cpu_features_add = Target.featureSet(&.{});
+            query.cpu_features_sub = Target.featureSet(&.{ .fp_armv8, .crypto, .neon });
+        },
+        .riscv64 => {
+            const Target = std.Target.riscv;
+
+            query.cpu_features_add = Target.featureSet(&.{});
+            query.cpu_features_sub = Target.featureSet(&.{.d});
+        },
+        .loongarch64 => {},
+    }
+
+    return query;
+}
+
+pub fn build(b: *std.Build) void {
+    const arch = b.option(Arch, "arch", "Architectue to build the kernel for") orelse .x86_64;
+
+    // We depend on the limine_zig package, which provides a module for
+    // interacting with the Limine bootloader. For more information about
+    // the Limine boot protocol, see:
+    // - https://github.com/limine-bootloader/limine/blob/trunk/PROTOCOL.md
+    // - https://github.com/limine-bootloader/limine/blob/trunk/limine.h
+    const limine_zig = b.dependency("limine_zig", .{ .api_revision = 3 });
+    const limine_module = limine_zig.module("limine");
+
+    const query = targetQueryForArch(arch);
+
+    // Resolve the target query and the standard optimization options.
+    // The optimization options can be overriden on the command line
+    // by passing the `-Doptimize=<option>` flag to the build command.
+    const target = b.resolveTargetQuery(query);
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Create a module for the kernel.
+    const kernel_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Specify the code model and other target-specific options.
+    switch (arch) {
+        .x86_64 => {
+            kernel_module.red_zone = false;
+            kernel_module.code_model = .kernel;
+        },
+        .aarch64, .riscv64, .loongarch64 => {},
+    }
+
+    // Add the limine module as an import to the kernel module.
+    kernel_module.addImport("limine", limine_module);
+
+    // Create an executable for the kernel using the kernel module.
+    const kernel = b.addExecutable(.{
+        .name = "kernel",
+        .root_module = kernel_module,
+    });
+
+    // Set the linker script for the kernel based on the architecture.
+    kernel.setLinkerScript(b.path(b.fmt("linker-{s}.lds", .{@tagName(arch)})));
+
+    // I am not sure whether it is the best way to override exe_dir, but it seems
+    // to work just fine - if you have a better idea, please let me know!
+    b.resolveInstallPrefix(null, .{ .exe_dir = b.fmt("bin-{s}", .{@tagName(arch)}) });
+    b.installArtifact(kernel);
+}

--- a/kernel/build.zig.zon
+++ b/kernel/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .limine_zig_template,
+    .version = "0.0.0",
+    .fingerprint = 0xcb5b2a3659f29f2f,
+    .minimum_zig_version = "0.14.0",
+    .dependencies = .{
+        .limine_zig = .{
+            .url = "git+https://github.com/48cf/limine-zig?ref=trunk#068d6fba7e73da8dfd0451903dbcd46aae5233fd",
+            .hash = "limine_zig-0.0.0-1TjwQLt6AABhFQNMnuvbeMr1UMviynJpZW_E51Dk0tCO",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/kernel/linker-aarch64.lds
+++ b/kernel/linker-aarch64.lds
@@ -1,0 +1,68 @@
+/* Tell the linker that we want an aarch64 ELF64 output file */
+OUTPUT_FORMAT(elf64-littleaarch64)
+
+/* We want the symbol _start to be our entry point */
+ENTRY(_start)
+
+/* Define the program headers we want so the bootloader gives us the right */
+/* MMU permissions; this also allows us to exert more control over the linking */
+/* process. */
+PHDRS
+{
+    limine_requests PT_LOAD;
+    text PT_LOAD;
+    rodata PT_LOAD;
+    data PT_LOAD;
+}
+
+SECTIONS
+{
+    /* We want to be placed in the topmost 2GiB of the address space, for optimisations */
+    /* and because that is what the Limine spec mandates. */
+    /* Any address in this region will do, but often 0xffffffff80000000 is chosen as */
+    /* that is the beginning of the region. */
+    . = 0xffffffff80000000;
+
+    /* Define a section to contain the Limine requests and assign it to its own PHDR */
+    .limine_requests : {
+        KEEP(*(.limine_requests_start))
+        KEEP(*(.limine_requests))
+        KEEP(*(.limine_requests_end))
+    } :limine_requests
+
+    /* Move to the next memory page for .text */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    /* Move to the next memory page for .rodata */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    /* Move to the next memory page for .data */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    /* NOTE: .bss needs to be the last thing mapped to :data, otherwise lots of */
+    /* unnecessary zeros will be written to the binary. */
+    /* If you need, for example, .init_array and .fini_array, those should be placed */
+    /* above this. */
+    .bss : {
+        *(.bss .bss.*)
+        *(COMMON)
+    } :data
+
+    /* Discard .note.* and .eh_frame* since they may cause issues on some hosts. */
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note .note.*)
+    }
+}

--- a/kernel/linker-loongarch64.lds
+++ b/kernel/linker-loongarch64.lds
@@ -1,0 +1,68 @@
+/* Tell the linker that we want a loongarch64 ELF64 output file */
+OUTPUT_FORMAT(elf64-loongarch)
+
+/* We want the symbol _start to be our entry point */
+ENTRY(_start)
+
+/* Define the program headers we want so the bootloader gives us the right */
+/* MMU permissions; this also allows us to exert more control over the linking */
+/* process. */
+PHDRS
+{
+    limine_requests PT_LOAD;
+    text PT_LOAD;
+    rodata PT_LOAD;
+    data PT_LOAD;
+}
+
+SECTIONS
+{
+    /* We want to be placed in the topmost 2GiB of the address space, for optimisations */
+    /* and because that is what the Limine spec mandates. */
+    /* Any address in this region will do, but often 0xffffffff80000000 is chosen as */
+    /* that is the beginning of the region. */
+    . = 0xffffffff80000000;
+
+    /* Define a section to contain the Limine requests and assign it to its own PHDR */
+    .limine_requests : {
+        KEEP(*(.limine_requests_start))
+        KEEP(*(.limine_requests))
+        KEEP(*(.limine_requests_end))
+    } :limine_requests
+
+    /* Move to the next memory page for .text */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    /* Move to the next memory page for .rodata */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    /* Move to the next memory page for .data */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    /* NOTE: .bss needs to be the last thing mapped to :data, otherwise lots of */
+    /* unnecessary zeros will be written to the binary. */
+    /* If you need, for example, .init_array and .fini_array, those should be placed */
+    /* above this. */
+    .bss : {
+        *(.bss .bss.*)
+        *(COMMON)
+    } :data
+
+    /* Discard .note.* and .eh_frame* since they may cause issues on some hosts. */
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note .note.*)
+    }
+}

--- a/kernel/linker-riscv64.lds
+++ b/kernel/linker-riscv64.lds
@@ -1,0 +1,70 @@
+/* Tell the linker that we want a riscv64 ELF64 output file */
+OUTPUT_FORMAT(elf64-littleriscv)
+
+/* We want the symbol _start to be our entry point */
+ENTRY(_start)
+
+/* Define the program headers we want so the bootloader gives us the right */
+/* MMU permissions; this also allows us to exert more control over the linking */
+/* process. */
+PHDRS
+{
+    limine_requests PT_LOAD;
+    text PT_LOAD;
+    rodata PT_LOAD;
+    data PT_LOAD;
+}
+
+SECTIONS
+{
+    /* We want to be placed in the topmost 2GiB of the address space, for optimisations */
+    /* and because that is what the Limine spec mandates. */
+    /* Any address in this region will do, but often 0xffffffff80000000 is chosen as */
+    /* that is the beginning of the region. */
+    . = 0xffffffff80000000;
+
+    /* Define a section to contain the Limine requests and assign it to its own PHDR */
+    .limine_requests : {
+        KEEP(*(.limine_requests_start))
+        KEEP(*(.limine_requests))
+        KEEP(*(.limine_requests_end))
+    } :limine_requests
+
+    /* Move to the next memory page for .text */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    /* Move to the next memory page for .rodata */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    /* Move to the next memory page for .data */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+        *(.sdata .sdata.*)
+    } :data
+
+    /* NOTE: .bss needs to be the last thing mapped to :data, otherwise lots of */
+    /* unnecessary zeros will be written to the binary. */
+    /* If you need, for example, .init_array and .fini_array, those should be placed */
+    /* above this. */
+    .bss : {
+        *(.sbss .sbss.*)
+        *(.bss .bss.*)
+        *(COMMON)
+    } :data
+
+    /* Discard .note.* and .eh_frame* since they may cause issues on some hosts. */
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note .note.*)
+    }
+}

--- a/kernel/linker-x86_64.lds
+++ b/kernel/linker-x86_64.lds
@@ -1,0 +1,68 @@
+/* Tell the linker that we want an x86_64 ELF64 output file */
+OUTPUT_FORMAT(elf64-x86-64)
+
+/* We want the symbol _start to be our entry point */
+ENTRY(_start)
+
+/* Define the program headers we want so the bootloader gives us the right */
+/* MMU permissions; this also allows us to exert more control over the linking */
+/* process. */
+PHDRS
+{
+    limine_requests PT_LOAD;
+    text PT_LOAD;
+    rodata PT_LOAD;
+    data PT_LOAD;
+}
+
+SECTIONS
+{
+    /* We want to be placed in the topmost 2GiB of the address space, for optimisations */
+    /* and because that is what the Limine spec mandates. */
+    /* Any address in this region will do, but often 0xffffffff80000000 is chosen as */
+    /* that is the beginning of the region. */
+    . = 0xffffffff80000000;
+
+    /* Define a section to contain the Limine requests and assign it to its own PHDR */
+    .limine_requests : {
+        KEEP(*(.limine_requests_start))
+        KEEP(*(.limine_requests))
+        KEEP(*(.limine_requests_end))
+    } :limine_requests
+
+    /* Move to the next memory page for .text */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    /* Move to the next memory page for .rodata */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    /* Move to the next memory page for .data */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    /* NOTE: .bss needs to be the last thing mapped to :data, otherwise lots of */
+    /* unnecessary zeros will be written to the binary. */
+    /* If you need, for example, .init_array and .fini_array, those should be placed */
+    /* above this. */
+    .bss : {
+        *(.bss .bss.*)
+        *(COMMON)
+    } :data
+
+    /* Discard .note.* and .eh_frame* since they may cause issues on some hosts. */
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note .note.*)
+    }
+}

--- a/kernel/src/main.zig
+++ b/kernel/src/main.zig
@@ -1,0 +1,38 @@
+const builtin = @import("builtin");
+const limine = @import("limine");
+
+export var start_marker: limine.RequestsStartMarker linksection(".limine_requests_start") = .{};
+export var end_marker: limine.RequestsEndMarker linksection(".limine_requests_end") = .{};
+
+export var base_revision: limine.BaseRevision linksection(".limine_requests") = .init(3);
+export var framebuffer_request: limine.FramebufferRequest linksection(".limine_requests") = .{};
+
+fn hcf() noreturn {
+    while (true) {
+        switch (builtin.cpu.arch) {
+            .x86_64 => asm volatile ("hlt"),
+            .aarch64 => asm volatile ("wfi"),
+            .riscv64 => asm volatile ("wfi"),
+            .loongarch64 => asm volatile ("idle 0"),
+            else => unreachable,
+        }
+    }
+}
+
+export fn _start() noreturn {
+    if (!base_revision.isSupported()) {
+        @panic("Base revision not supported");
+    }
+
+    if (framebuffer_request.response) |framebuffer_response| {
+        const framebuffer = framebuffer_response.getFramebuffers()[0];
+        for (0..100) |i| {
+            const fb_ptr: [*]volatile u32 = @ptrCast(@alignCast(framebuffer.address));
+            fb_ptr[i * (framebuffer.pitch / 4) + i] = 0xffffff;
+        }
+    } else {
+        @panic("Framebuffer response not present");
+    }
+
+    hcf();
+}

--- a/limine.conf
+++ b/limine.conf
@@ -1,0 +1,10 @@
+# Timeout in seconds that Limine will use before automatically booting.
+timeout: 3
+
+# The entry name that will be displayed in the boot menu.
+/ZernOS
+    # We use the Limine boot protocol.
+    protocol: limine
+
+    # Path to the kernel to boot. boot():/ represents the partition on which limine.conf is located.
+    kernel_path: boot():/boot/kernel


### PR DESCRIPTION
## Обзор от Sourcery

Перенос сборки ядра на Zig с интеграцией загрузчика Limine и добавление GNUmakefile верхнего уровня для автоматизации сборки, упаковки и запуска загрузочных образов ISO/HDD для x86_64, aarch64, riscv64 и loongarch64.

Новые возможности:
- Перенос сборки ядра на Zig с использованием скрипта `build.zig` и пакета `limine_zig`
- Добавление GNUmakefile верхнего уровня для сборки образов ISO/HDD, получения прошивки OVMF и предоставления целей запуска QEMU для нескольких архитектур.
- Добавление `kernel/src/main.zig`, реализующего запросы протокола Limine и базовую инициализацию фреймбуфера.
- Добавление `limine.conf` для настройки параметров загрузчика Limine.

Улучшения:
- Предоставление ELF-скриптов линковщика для конкретных архитектур, встраивающих разделы запросов Limine и макет памяти.
- Автоматизация установки Limine на сгенерированные образы ISO и HDD в режимах BIOS и UEFI.
- Поддержка автоматического получения бинарных файлов OVMF для эмуляции UEFI во время сборки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the kernel build to Zig with Limine bootloader integration and introduce a top-level GNUmakefile to automate building, packaging, and running bootable ISO/HDD images across x86_64, aarch64, riscv64, and loongarch64.

New Features:
- Migrate kernel build to Zig using a build.zig script and the limine_zig package
- Add a top-level GNUmakefile to assemble ISO/HDD images, fetch OVMF firmware, and provide QEMU run targets for multiple architectures
- Introduce kernel/src/main.zig implementing Limine protocol requests and basic framebuffer initialization
- Add limine.conf to configure Limine bootloader settings

Enhancements:
- Provide architecture-specific ELF linker scripts embedding Limine request sections and memory layout
- Automate Limine installation onto generated ISO and HDD images in both BIOS and UEFI modes
- Support fetching OVMF binaries for UEFI emulation automatically during the build

</details>